### PR TITLE
Add algorithms for computing rankings

### DIFF
--- a/ftw.opam
+++ b/ftw.opam
@@ -26,6 +26,8 @@ depends: [
   "otoml"
   "ppx_deriving"
   "ppx_deriving_yojson"
+  "printbox"
+  "printbox-text"
   "odoc" {with-doc}
   "sherlodoc" {with-doc}
 ]

--- a/src/backend/artefact.ml
+++ b/src/backend/artefact.ml
@@ -19,8 +19,9 @@ let convert_result_list_to_list_result a =
 let get_heat_followers (sh: Ftw.Heat.singles_heats) =
   let target_list_array =
     Array.map (fun (singles_heat: Ftw.Heat.singles_heat) ->
-        List.map (fun (d: Ftw.Heat.single) -> let dancer_id = d.dancer in
-                   Ftw.Bib.Any (Single {target=dancer_id; role=Ftw.Role.Follower;}))
+        List.map (fun (d: Ftw.Heat.single) ->
+            let dancer_id = d.dancer in
+            Ftw.Target.Any (Single {target=dancer_id; role=Ftw.Role.Follower;}))
           singles_heat.followers) sh.singles_heats
   in
   Array.to_list target_list_array
@@ -28,8 +29,9 @@ let get_heat_followers (sh: Ftw.Heat.singles_heats) =
 let get_heat_leaders (sh: Ftw.Heat.singles_heats) =
   let target_list_array =
     Array.map (fun (singles_heat: Ftw.Heat.singles_heat) ->
-        List.map (fun (d: Ftw.Heat.single) -> let dancer_id = d.dancer in
-                   Ftw.Bib.Any (Single {target=dancer_id; role=Ftw.Role.Leader;}))
+        List.map (fun (d: Ftw.Heat.single) ->
+            let dancer_id = d.dancer in
+            Ftw.Target.Any (Single {target=dancer_id; role=Ftw.Role.Leader;}))
           singles_heat.leaders) sh.singles_heats
   in
   Array.to_list target_list_array
@@ -38,7 +40,7 @@ let get_heat_couples (ch:Ftw.Heat.couples_heats) =
   let target_list_array =
     Array.map (fun (couples_heat: Ftw.Heat.couples_heat) ->
         List.map (fun (couple:Ftw.Heat.couple) ->
-            Ftw.Bib.Any (Couple {leader=couple.leader;follower=couple.follower}))
+            Ftw.Target.Any (Couple {leader=couple.leader;follower=couple.follower}))
           couples_heat.couples) ch.couples_heats
   in
   Array.to_list target_list_array

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -77,6 +77,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2053,6 +2054,7 @@
       "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.8.2.tgz",
       "integrity": "sha512-1AwKjBWmyWWA7dGCRjn2glWwO6cA7dDX7roP1tosFi5cu1EvqHaqelRH6K6MZSV10Tv6oPtFG7rgV+rCafJvyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-router/express": "7.8.2",
         "@react-router/node": "7.8.2",
@@ -2655,6 +2657,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.5.tgz",
       "integrity": "sha512-/X4EFNcnPiSs8wM2v+b6DqS5mmGeuJQvxBglmDxl6ZQb5V26ouD2SJYAcC3VjbNwqhY2zjxVD15rDA5nGbMn3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.85.5"
       },
@@ -2704,6 +2707,7 @@
       "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2721,6 +2725,7 @@
       "integrity": "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2731,6 +2736,7 @@
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2893,6 +2899,7 @@
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -3025,6 +3032,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -3504,6 +3512,7 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3957,6 +3966,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -5430,6 +5440,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5649,6 +5660,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5701,6 +5713,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5813,6 +5826,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
       "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -6625,6 +6639,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6802,6 +6817,7 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/hookgen/package-lock.json
+++ b/src/hookgen/package-lock.json
@@ -1166,6 +1166,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2805,6 +2806,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -4219,6 +4221,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5300,6 +5303,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6424,7 +6428,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "json-schema-traverse": {
       "version": "1.0.0",
@@ -7443,7 +7448,8 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "uc.micro": {
       "version": "2.1.0",

--- a/src/lib/artefact.mli
+++ b/src/lib/artefact.mli
@@ -43,6 +43,10 @@ type t =
 val check : descr:Descr.t -> t -> bool
 (** Check whether an artefact matches a description. *)
 
+val print : Format.formatter -> t -> unit
+
+val printbox : t -> PrintBox.t
+
 
 (* DB Interaction *)
 (* ************************************************************************* *)

--- a/src/lib/bib.mli
+++ b/src/lib/bib.mli
@@ -7,46 +7,19 @@
 type t = Id.t
 (** Bibs are integers *)
 
-type 'kind target =
-  | Single :
-      { target : Id.t; role : Role.t; } -> [`Single] target
-  (** *)
-  | Couple :
-      { leader : Id.t; follower : Id.t; } -> [`Couple] target
-  (** *)
-(** The target that a bib can have: a bib can sometime refer to a single
-    dancer (e.g. during a Jack&Jill), but also to a couple (e.g. in a
-    Strictly).
-    In case of couple, give them both the same bib.
-    *)
-
-type any_target = Any : _ target -> any_target
-(** Existencial wrapper around the GADT. *)
-
-
-(* Serialization *)
-(* ************************************************************************* *)
-
-val to_toml : any_target -> Otoml.t
-(** Serialization to toml. *)
-
-val of_toml : Otoml.t -> any_target
-(** Deserialization from toml.
-    @raise Otoml.Type_error *)
-
 
 (* DB interaction *)
 (* ************************************************************************* *)
 
-val get : st:State.t -> competition:Competition.id -> bib:t -> any_target option
+val get : st:State.t -> competition:Competition.id -> bib:t -> Id.t Target.any option
 (** Get the target of a bib, if it exists. *)
 
-val get_all : st:State.t -> competition:Competition.id -> (t * any_target) list
+val get_all : st:State.t -> competition:Competition.id -> (t * Id.t Target.any) list
 (** Get all bibs from a competition *)
 
 val add :
   st:State.t -> competition:Competition.id ->
-  target:any_target -> bib:t -> unit
+  target:Id.t Target.any -> bib:t -> unit
 (** Set the bib for a given target in a competition. *)
 
 val delete :

--- a/src/lib/bonus.ml
+++ b/src/lib/bonus.ml
@@ -5,8 +5,7 @@
 (* ************************************************************************* *)
 
 type t = int
-(* Bonus are integers *)
-
+(* Bonus are positive integers *)
 
 (* DB interaction *)
 (* ************************************************************************* *)
@@ -24,10 +23,14 @@ let () =
         )
       |})
 
+let zero = 0
+
 let get ~st ~target =
-  State.query_one_where ~st ~p:Id.p ~conv
-    {| SELECT bonus FROM bonus WHERE target_id = ? |}
-    target
+  try
+    Some (State.query_one_where ~st ~p:Id.p ~conv
+            {| SELECT bonus FROM bonus WHERE target_id = ? |}
+            target)
+  with Sqlite3_utils.RcError NOTFOUND -> None
 
 let set ~st ~target bonus =
   let open Sqlite3_utils.Ty in

--- a/src/lib/bonus.mli
+++ b/src/lib/bonus.mli
@@ -16,7 +16,10 @@ val p : (t -> 'a, 'a) Sqlite3_utils.Ty.t
 val conv : t Conv.t
 (** Converter for identifiers *)
 
-val get : st:State.t -> target:Id.t -> int
+val zero : t
+(** The zero bonus. *)
+
+val get : st:State.t -> target:Id.t -> int option
 (** Get the bonus for J&J and strictlys. *)
 
 val set : st:State.t -> target:Id.t -> int -> unit

--- a/src/lib/category.ml
+++ b/src/lib/category.ml
@@ -77,7 +77,7 @@ let p = Sqlite3_utils.Ty.([int])
 let conv = Conv.mk p of_int
 
 let () =
-  State.add_init_descr_table
+  State.add_init_descr_table ()
     ~table_name:"competition_categories" ~to_int
     ~to_descr:to_string ~values:[
       Non_competitive Regular;

--- a/src/lib/dancer.ml
+++ b/src/lib/dancer.ml
@@ -195,7 +195,7 @@ let update_divisions ~st ~dancer ~role ~divs =
 
 module Index = struct
 
-  let src = Logs.Src.create "ftw.dancer.index"
+  let src = Logs.Src.create "ftw.index"
 
   type dancer = t
   type t = dancer Str.Index.t Str.Index.t

--- a/src/lib/division.ml
+++ b/src/lib/division.ml
@@ -50,7 +50,7 @@ let p = Sqlite3_utils.Ty.([int])
 let conv = Conv.mk p of_int
 
 let () =
-  State.add_init_descr_table
+  State.add_init_descr_table ()
     ~table_name:"division_names" ~to_int
     ~to_descr:to_string ~values:[
       Novice;

--- a/src/lib/divisions.ml
+++ b/src/lib/divisions.ml
@@ -87,7 +87,7 @@ let p = Sqlite3_utils.Ty.([int])
 let conv = Conv.mk p of_int
 
 let () =
-  State.add_init_descr_table
+  State.add_init_descr_table ()
     ~table_name:"divisions_names" ~to_int
     ~to_descr:to_string ~values:[
     None;

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -9,6 +9,7 @@
   (libraries
     unix fmt logs
     gen containers
+    printbox printbox-text
     sqlite3 sqlite3_utils
     otoml spelll uutf uunf
   )

--- a/src/lib/heat.mli
+++ b/src/lib/heat.mli
@@ -49,12 +49,6 @@ type t =
   | Couples of couples_heats (**)
 (** Uniform type for heats *)
 
-type one =
-  | Single of Role.t * single
-  | Couple of couple
-(** Type for a single target *)
-
-
 
 (* Serialization *)
 (* ************************************************************************* *)
@@ -68,12 +62,33 @@ val couples_heats_to_toml : couples_heats -> Otoml.t
 val couples_heats_of_toml : Otoml.t -> couples_heats
 
 
+(* Heat helpers *)
+(* ************************************************************************* *)
+
+val all_single_judgement_targets : singles_heats ->
+  ([ `Single ], Id.t) Target.t Id.Map.t * Id.t list * Id.t list
+
+val all_couple_judgement_targets : couples_heats ->
+  ([ `Couple ], Id.t) Target.t Id.Map.t
+
+type 'target ranking =
+  | Singles of {
+      leaders : 'target Ranking.Res.t;
+      follows : 'target Ranking.Res.t;
+    }
+  | Couples of {
+      couples : 'target Ranking.Res.t;
+    }
+
+val ranking : st:State.t -> phase:Phase.id -> Id.t ranking
+
+
 (* DB interaction *)
 (* ************************************************************************* *)
 
 
 (* TODO: review/remove these *)
-val get_id : State.t -> Phase.id -> int -> Bib.any_target -> (Id.t option, string) result
+val get_id : State.t -> Phase.id -> int -> Id.t Target.any -> (Id.t option, string) result
 val simple_init : State.t -> phase:Phase.id -> int -> int -> unit
 val simple_promote : State.t -> phase:Phase.id -> int -> unit
 
@@ -85,7 +100,7 @@ val add_couple :
   st:State.t -> phase:Phase.id ->
   heat:int -> leader:Dancer.id -> follower:Dancer.id -> target_id
 
-val get_one : st:State.t -> target_id -> one
+val get_one : st:State.t -> target_id -> Id.t Target.any
 
 val get : st:State.t -> phase:Phase.id -> t
 val get_singles : st:State.t -> phase:Phase.id -> singles_heats

--- a/src/lib/judging.ml
+++ b/src/lib/judging.ml
@@ -41,7 +41,7 @@ let conv =
   Conv.mk Sqlite3_utils.Ty.[int] of_int
 
 let () =
-  State.add_init_descr_table
+  State.add_init_descr_table ()
     ~table_name:"judging_names" ~to_int
     ~to_descr:to_string ~values:[
       Head; Couples;

--- a/src/lib/kind.ml
+++ b/src/lib/kind.ml
@@ -54,7 +54,7 @@ let p = Sqlite3_utils.Ty.([int])
 let conv = Conv.mk p of_int
 
 let () =
-  State.add_init_descr_table
+  State.add_init_descr_table ()
     ~table_name:"competition_kinds" ~to_int ~to_descr:to_string
     ~values:[Routine; Strictly; JJ_Strictly; Jack_and_Jill]
 

--- a/src/lib/misc.ml
+++ b/src/lib/misc.ml
@@ -42,6 +42,17 @@ module Lists = struct
 
 end
 
+(* Matrix *)
+(* ************************************************************************* *)
+
+module Matrix = struct
+
+  let (++) a b =
+    assert (Array.length a = Array.length b);
+    Array.map2 Array.append a b
+
+end
+
 (* Bitwise manipulations *)
 (* ************************************************************************* *)
 

--- a/src/lib/misc.mli
+++ b/src/lib/misc.mli
@@ -43,6 +43,16 @@ module Lists : sig
 
 end
 
+(* Lists *)
+(* ************************************************************************* *)
+
+module Matrix : sig
+
+  val (++) : 'a array array -> 'a array array -> 'a array array
+  (** Concatenates two matrix with the same number of lines. *)
+
+end
+
 (* Bitwise manipulations *)
 (* ************************************************************************* *)
 

--- a/src/lib/phase.ml
+++ b/src/lib/phase.ml
@@ -79,6 +79,10 @@ let find st competition_id =
   State.query_list_where ~p:Id.p ~conv ~st
     {| SELECT * FROM phases WHERE competition_id = ? ORDER BY id |} competition_id
 
+let find_round st competition_id r =
+  let phases = find st competition_id in
+  List.find_opt (fun phase -> Round.equal r (round phase)) phases
+
 let create
     ~st competition_id round
     ~ranking_algorithm
@@ -153,4 +157,5 @@ let delete ~st id_phase =
     {| DELETE FROM phases
         WHERE id=?|} id_phase;
   id_phase
+
 

--- a/src/lib/phase.mli
+++ b/src/lib/phase.mli
@@ -52,6 +52,9 @@ val find : State.t -> Competition.id -> t list
 val find_ids : State.t -> Competition.id -> id list
 (** Optimized version of {!find} that only returns phases ids. *)
 
+val find_round : State.t -> Competition.id -> Round.t -> t option
+(** Try and find the given round for the competition. *)
+
 val create :
   st:State.t -> Competition.id -> Round.t ->
   ranking_algorithm:Ranking.Algorithm.t ->

--- a/src/lib/points.ml
+++ b/src/lib/points.ml
@@ -24,15 +24,16 @@ let base finals ~semis =
   { finals; semifinals = semis; }
 
 let apply rule = function
-  | Finals Some i ->
-    if i <= Array.length rule.finals
-    then rule.finals.(i - 1)
+  | Finals Some rank ->
+    let i = Rank.to_index rank in
+    if i <= (Array.length rule.finals) - 1
+    then rule.finals.(i)
     else 0
   | Semifinals -> rule.semifinals
   | Finals None | Other -> 0
 
 
-(* Rules by date *)
+(* Points won by date/placement/number of competitors *)
 (* ************************************************************************* *)
 
 module IM = Interval.Map.Make(struct
@@ -62,6 +63,15 @@ let rules : rules =
         21, base [| 12; 10; 8; 6; 6; 3; 3; 3; 3; 3 |] ~semis:0;
         31, base [| 14; 12; 10; 8; 8; 6; 6; 3; 3; 3 |] ~semis:1;
         46, base [| 16; 14; 12; 10; 10; 8; 8; 6; 6; 6 |] ~semis:2;
+      ];
+    Date.mk ~day:9 ~month:7 ~year:2025,
+    IM.of_list [
+        1, base [| 6; 4; 2 |] ~semis:0;
+        11, base [| 8; 6; 4; 2; 1 |] ~semis:0;
+        21, base [| 10; 8; 6; 4; 2; 1; 1; 1; 1; 1 |] ~semis:0;
+        31, base [| 12; 10; 8; 6; 4; 2; 2; 2; 2; 2 |] ~semis:1;
+        46, base [| 14; 12; 10; 8; 6; 4; 4; 4; 2; 2 |] ~semis:1;
+        66, base [| 16; 14; 12; 10; 8; 6; 6; 6; 4; 4; 2; 2; 2; 2 |] ~semis:1;
       ];
   ]
 

--- a/src/lib/rank.ml
+++ b/src/lib/rank.ml
@@ -29,6 +29,8 @@ let of_toml t =
 (* Usual functions *)
 (* ************************************************************************* *)
 
+let print fmt r = Format.fprintf fmt "%d" r
+
 let compare (r : t) r' = Stdlib.compare r r'
 
 let equal r r' = compare r r' = 0
@@ -42,3 +44,16 @@ module Set = Set.Make(Aux)
 module Map = Map.Make(Aux)
 
 
+(* Creation / use *)
+(* ************************************************************************* *)
+
+(* Conversion functions to/from human-readable ranks *)
+let mk i = i
+let rank i = i
+
+(* Ranks are stored starting at 1, but indexes start from 0 *)
+let to_index r = r - 1
+let of_index i = i + 1
+
+(* rank increase *)
+let next r = r + 1

--- a/src/lib/rank.mli
+++ b/src/lib/rank.mli
@@ -4,9 +4,23 @@
 (* Type definitions *)
 (* ************************************************************************* *)
 
-type t = int
-(** A rank is represented as an integer. [1] represents first place,
-    [2] second palce, and so on... *)
+type t
+(** A rank. *)
+
+
+(* Conversions *)
+(* ************************************************************************* *)
+
+val mk : int -> t
+val rank : t -> int
+(* Human-readable conversions: the first place is the int [1], and so on ...*)
+
+val of_index : int -> t
+val to_index : t -> int
+(* Conversions to/from indexes, where the first rank is [0] *)
+
+val next : t -> t
+(** Next rank *)
 
 
 (* DB interaction *)
@@ -32,6 +46,9 @@ val of_toml : Otoml.t -> t
 
 (* Usual functions *)
 (* ************************************************************************* *)
+
+val print : Format.formatter -> t -> unit
+(** Print *)
 
 val equal : t -> t -> bool
 (** Equality function *)

--- a/src/lib/ranking.ml
+++ b/src/lib/ranking.ml
@@ -1,144 +1,683 @@
 
 (* This file is free software, part of FTW. See file "LICENSE" for more information *)
 
-(* Type description *)
-(* ************************************************************************* *)
-(*
-type ('target, 'acc) target = {
-  target : 'target;
-  heat_target_id : Id.t; (* = Heat.target_id *)
-  ranking_acc : 'acc;
-}
+let src = Logs.Src.create "ftw.ranking"
 
-type ('target, 'acc) ranked =
-  | Rank of ('target, 'acc) target
-  | Tie of {
-      rank : int;
-      tie : ('target, 'acc) target array;
-    }
-
-type ('target, 'acc) t = ('target, 'acc) ranked array
-
-type status = Ranked | Tied
-
-
-(* Printing functions *)
+(* Base types *)
 (* ************************************************************************* *)
 
-let target n t =
-  match t.(n) with
-  | Rank target -> Ranked, n, target
-  | Tie { rank; tie; } -> Tied, rank, tie.(n - rank)
+module Status = struct
 
-let grid_init ~pp t ~line ~col =
-  let status, rank, target = target line t in
-  match col, status with
-  | `Rank, Ranked -> PrintBox.int rank
-  | `Rank, Tied ->
-    PrintBox.asprintf_with_style
-      { PrintBox.Style.default with bold = true; fg_color = Some Red; }
-      "%d" rank
-  | `Heat_target_id, _ ->
-    PrintBox.asprintf "%d" target.heat_target_id
-  | `Target, _ -> pp target.target
-  | _ -> assert false
-*)
+  type t =
+    | Complete
+    | Partial
+    | Impossible
 
-(* Algorithms for creating rankings *)
+  let print fmt = function
+    | Complete -> ()
+    | Partial -> Format.fprintf fmt "!! partial !!"
+    | Impossible -> Format.fprintf fmt "?? cannot rank ??"
+
+end
+
+(* One ranking *)
 (* ************************************************************************* *)
 
-module Algorithm = struct
+module One = struct
 
-  type yan_weight = {
+  type 'a ranked =
+    | None
+    | Ranked of {
+        rank : Rank.t;
+        target : 'a;
+      }
+    | Tie of {
+        rank : Rank.t;
+        tie : 'a array;
+      }
+
+
+  (** Array of Ranked *)
+  type 'a t = {
+    ranks : 'a ranked array;
+  }
+
+  type with_heat_ids = Id.t t
+
+  let empty n =
+    { ranks = Array.make n None; }
+
+  let get { ranks; } r =
+    let i = Rank.to_index r in
+    match ranks.(i) with
+    | None -> Option.None
+    | Ranked { target; rank } -> Some (rank, target)
+    | Tie { rank; tie; } -> Some (rank, tie.(i - Rank.to_index rank))
+
+  let set { ranks; } i tie =
+    if Array.length tie = 1 then
+      ranks.(i) <- Ranked { rank = Rank.of_index i; target = tie.(0); }
+    else begin
+      for j = i to i + Array.length tie - 1 do
+        ranks.(j) <- Tie { rank = Rank.of_index i; tie; }
+      done
+    end
+
+  let map_targets ~f { ranks; } =
+    let ranks =
+      Array.map (function
+          | None -> None
+          | Ranked { rank; target; } ->
+            Ranked { rank; target = f target; }
+          | Tie { rank; tie; } ->
+            Tie { rank; tie = Array.map f tie; }
+        ) ranks
+    in
+    { ranks; }
+
+  let printbox_matrix ~pp { ranks } =
+    let n = Array.length ranks in
+    let m = 2 in
+    let matrix = Array.make_matrix n m PrintBox.empty in
+    for line = 0 to n - 1 do
+      for col = 0 to m - 1 do
+        let contents =
+          match col with
+          | 0 ->
+            begin match ranks.(line) with
+              | Ranked _ -> PrintBox.int (line + 1)
+              | Tie { rank; _ } when Rank.to_index rank = line -> PrintBox.int (line + 1)
+              | Tie _ -> PrintBox.empty
+              | None -> PrintBox.asprintf "n/a"
+            end
+          | 1 ->
+            let target_id_opt : _ option =
+              match ranks.(line) with
+              | None -> None
+              | Ranked { rank = _; target; } -> Some target
+              | Tie { rank; tie; } -> Some (tie.(line - Rank.to_index rank))
+            in
+            begin match target_id_opt with
+              | None -> PrintBox.empty
+              | Some target -> PrintBox.asprintf "%a" pp target
+            end
+          | _ -> assert false
+        in
+        matrix.(line).(col) <- contents
+      done
+    done;
+    matrix
+
+  let print ~pp fmt t =
+    let box = PrintBox.grid ~bars:true (printbox_matrix ~pp t) in
+    PrintBox_text.pp fmt box
+
+end
+
+
+(* Artefact Matrix *)
+(* *********************************************************************** *)
+
+module Matrix = struct
+
+  type ('acc, 'target) t = {
+    (* info about judges *)
+    head : bool;
+    judges : 'target array;
+    (* info about targets *)
+    targets : 'target array;
+    (* artefacts (and bonus) for each target/judge pair *)
+    mutable missing_artefacts : int;
+    artefacts : Artefact.t option array array;
+    bonus : Bonus.t array;
+    (* accumulator for ranking algorithms *)
+    ranking_acc : 'acc array;
+    (* resulting ranking *)
+    ranks : 'target One.t;
+  }
+
+  (* accessors *)
+
+  let ranks t = t.ranks
+
+  let length t =
+    Array.length t.artefacts
+
+  let width t =
+    Array.length t.artefacts.(0)
+
+  let target t ~i =
+    t.targets.(i)
+
+  let judge t ~j =
+    t.judges.(j)
+
+  let bonus t ~i =
+    t.bonus.(i)
+
+  let head t =
+    if t.head then Some 0 else None
+
+  let is_head t ~j =
+    j = 0 && t.head
+
+  let missing_artefacts t = t.missing_artefacts
+
+  let artefact t ~i ~j =
+    match t.artefacts.(i).(j) with
+    | None -> failwith "missing artefact"
+    | Some artefact -> artefact
+
+  (* debug printing *)
+
+  let printbox_matrix ~acc_line ~acc_side ~pp t =
+    let ranks = One.printbox_matrix ~pp t.ranks in
+    let acc = Array.map acc_line t.ranking_acc in
+    let targets = Array.map (fun target -> [| PrintBox.asprintf "%a" pp target |]) t.targets in
+    let artefacts =
+      Array.map (Array.map (function
+          | None -> PrintBox.empty
+          | Some artefact -> Artefact.printbox artefact
+        )) t.artefacts
+    in
+    let blank = Array.make (Array.length artefacts) [|PrintBox.empty|] in
+    match acc_side with
+    | `Left -> Misc.Matrix.(ranks ++ blank ++ acc ++ blank ++ artefacts ++ blank ++ targets)
+    | `Right -> Misc.Matrix.(ranks ++ blank ++ artefacts ++ blank ++ acc ++ blank ++ targets)
+
+  let printbox ~acc_line ~acc_side ~pp t =
+    let matrix = printbox_matrix ~acc_line ~acc_side ~pp t in
+    PrintBox.grid matrix
+
+  (* initialization *)
+
+  let init ~head ~judges ~targets ~acc =
+    let targets = Array.of_list targets in
+    let judges =
+      Array.of_list @@
+      match head with
+      | Some h -> h ::judges
+      | None -> judges
+    in
+    let m = Array.length judges in
+    let n = Array.length targets in
+    let head = Option.is_some head in
+    let bonus = Array.make n Bonus.zero in
+    let artefacts = Array.make_matrix n m None in
+    let missing_artefacts = n * m in
+    let ranking_acc = Array.init n (fun _ -> acc n) in
+    let ranks = One.empty n in
+    let t = { head; judges; targets; artefacts; bonus; missing_artefacts; ranking_acc; ranks; } in
+    Logs.debug ~src (fun k->k "matrix init: %d targets, %d judges" n m);
+    t
+
+  let map ~targets:f ~judges:g t =
+    let judges = Array.map g t.judges in
+    let targets = Array.map f t.targets in
+    let ranks = One.map_targets ~f t.ranks in
+    { t with targets; judges; ranks;  }
+
+  (* filing up the matrix with artefacts *)
+
+  let acc_bonus ~i ~bonus t =
+    t.bonus.(i) <- bonus
+
+  let acc_artefact ~i ~j ~artefact t =
+    match t.artefacts.(i).(j) with
+    | None ->
+      t.missing_artefacts <- t.missing_artefacts - 1;
+      t.artefacts.(i).(j) <- Some artefact
+    | Some _ -> failwith "duplicate artefact"
+
+  (* Ranking helpers *)
+
+  let get ~i t =
+    t.ranking_acc.(i)
+
+  let set ~i t a =
+    t.ranking_acc.(i) <- a
+
+  let swap t i j =
+    (* swap should only be called on "unranked" targets *)
+    CCArray.swap t.bonus i j;
+    CCArray.swap t.targets i j;
+    CCArray.swap t.artefacts i j;
+    CCArray.swap t.ranking_acc i j
+
+  let rec sort ~cmp ~start ~stop t =
+    (* for now we use bubble sort, as it is simpler,
+       but any other sort algo would work *)
+    let swapped = ref false in
+    for i = start + 1 to stop do
+      if cmp t.ranking_acc.(i - 1) t.ranking_acc.(i) > 0 then begin
+        swap t (i - 1) i;
+        swapped := true
+      end
+    done;
+    if !swapped then sort ~cmp ~start ~stop t
+
+  let rec segments ~cmp ~start ~stop ~f t =
+    if start > stop then ()
+    else begin
+      let base = t.ranking_acc.(start) in
+      let cursor = ref (start + 1) in
+      while !cursor <= stop &&
+            cmp base t.ranking_acc.(!cursor) = 0 do
+        incr cursor
+      done;
+      f ~start ~stop:(!cursor - 1);
+      segments ~cmp ~start:(!cursor) ~stop ~f t
+    end
+
+end
+
+(* Algorithms - Yan wieghted *)
+(* *********************************************************************** *)
+
+module Yan_weighted = struct
+
+  type weight = {
     yes : int;
     alt : int;
     no : int;
   } [@@deriving yojson]
 
-  type t =
-    | RPSS
-    | Yan_weighted of {
-        weights : yan_weight list;
-        head_weights : yan_weight list;
-      }
-  [@@deriving yojson]
+  type conf = {
+    weights : weight list;
+    head_weights : weight list;
+  } [@@deriving yojson]
 
-  (* Usual functions *)
-  (* *********************************************************************** *)
+  (* printing *)
 
-  let print_yan_weight fmt { yes; alt; no; } =
+  let print_weight fmt { yes; alt; no; } =
     Format.fprintf fmt "%d/%d/%d" yes alt no
 
-  let print_yan_weights fmt l =
+  let print_weights fmt l =
     match Misc.Lists.all_the_same ~eq:(=) l with
     | Some t when List.length l > 1 ->
-      Format.fprintf fmt "@@(%a)" print_yan_weight t
+      Format.fprintf fmt "@@(%a)" print_weight t
     | _ ->
       let pp_sep fmt () = Format.fprintf fmt ",@ " in
-      Format.pp_print_list ~pp_sep print_yan_weight fmt l
+      Format.pp_print_list ~pp_sep print_weight fmt l
 
-  let print fmt = function
-    | RPSS ->
-      Format.fprintf fmt "RPSS"
-    | Yan_weighted { weights; head_weights; } ->
-      Format.fprintf fmt "%a / %a"
-        print_yan_weights weights
-        print_yan_weights head_weights
+  let print_conf fmt { weights; head_weights; } =
+    Format.fprintf fmt "%a / %a"
+      print_weights weights
+      print_weights head_weights
 
+  (* serialization *)
 
-  (* Algorithms Serialization *)
-  (* *********************************************************************** *)
-
-  let yan_weight_to_toml { yes; alt; no; } =
+  let weight_to_toml { yes; alt; no; } =
     Otoml.inline_table [
       "yes", Otoml.integer yes;
       "alt", Otoml.integer alt;
       "no", Otoml.integer no;
     ]
 
-  let yan_weight_of_toml t =
+  let weight_of_toml t =
     let yes = Otoml.find_exn t Otoml.get_integer ["yes"] in
     let alt = Otoml.find_exn t Otoml.get_integer ["alt"] in
     let no = Otoml.find_exn t Otoml.get_integer ["no"] in
     { yes; alt; no; }
 
-  let yan_weights_to_toml l =
-    Otoml.array (List.map yan_weight_to_toml l)
+  let weights_to_toml l =
+    Otoml.array (List.map weight_to_toml l)
 
-  let yan_weights_of_toml t =
-    Otoml.get_array yan_weight_of_toml t
+  let weights_of_toml t =
+    Otoml.get_array weight_of_toml t
+
+  let conf_to_toml { weights; head_weights; } =
+    [ weights_to_toml weights;
+      weights_to_toml head_weights ]
+
+  let conf_of_toml = function
+    | [ w; h_w ] ->
+      let weights = weights_of_toml w in
+      let head_weights = weights_of_toml h_w in
+      { weights; head_weights; }
+    | _ ->
+      assert false (* TODO: error msg *)
+
+
+  (* creating and computing the ranking accumulator *)
+
+  type acc = {
+    judges : int;
+    head : int;
+    bonus : Bonus.t;
+  }
+
+  let acc_line { judges; head; bonus; } =
+    [| PrintBox.asprintf "%d / %d%s"
+         judges head
+         (if bonus = 0 then "" else Format.asprintf ".%d" bonus) |]
+
+  let acc _n = { judges = 0; head = 0; bonus = 0; }
+
+  let extract artefact =
+    match (artefact : Artefact.t) with
+    | Yans l -> l
+    | _ -> failwith "bad artefact"
+
+  let sum yans weights =
+    List.fold_left2 (fun sum yan weights ->
+        let x =
+          match (yan : Artefact.yan) with
+          | Yes -> weights.yes
+          | Alt -> weights.alt
+          | No -> weights.no
+        in
+        sum + x
+      ) 0 yans weights
+
+  let compute_totals ~conf matrix =
+    for i = 0 to Matrix.length matrix - 1 do
+      let bonus = Matrix.bonus matrix ~i in
+      let acc = ref ({ (acc ()) with bonus }) in
+      for j = 0 to Matrix.width matrix - 1 do
+        let yans = extract @@ Matrix.artefact matrix ~i ~j in
+        let weights =
+          if Matrix.is_head matrix ~j
+          then conf.head_weights
+          else conf.weights
+        in
+        let total = sum yans weights in
+        acc :=
+          if Matrix.is_head matrix ~j
+          then { !acc with head = total; }
+          else { !acc with judges = !acc.judges + total }
+      done;
+      Matrix.set matrix ~i !acc
+    done
+
+  let rank ~conf matrix =
+    (* some small helpers *)
+    let n = Matrix.length matrix in
+    let cmp
+        { judges = j1; head = h1; bonus = b1; }
+        { judges = j2; head = h2; bonus = b2; } =
+      CCOrd.(int j2 j1 <?> (int, h2, h1) <?> (int, b2, b1))
+    in
+    (* comoute total scores  sort the matrix *)
+    compute_totals ~conf matrix;
+    Matrix.sort matrix ~cmp ~start:0 ~stop:(n - 1);
+    Matrix.segments matrix ~cmp ~start:0 ~stop:(n - 1)
+      ~f:(fun ~start ~stop ->
+          let tie =
+            Array.init (stop - start + 1)
+              (fun i -> Matrix.target matrix ~i:(start + i))
+          in
+          One.set (Matrix.ranks matrix) start tie
+        );
+    (* generate output status *)
+    if Matrix.missing_artefacts matrix = 0
+    then Status.Complete
+    else Status.Partial
+
+end
+
+(* Algorithms - RPSS *)
+(* *********************************************************************** *)
+
+module RPSS = struct
+
+  type conf = unit
+  [@@deriving yojson]
+
+  type cell = {
+    mutable votes : int option;
+    mutable sum : int option;
+    mutable head : int option;
+  }
+
+  type acc = cell array
+
+  let acc_line acc =
+    Array.map (function { votes; sum; head; } ->
+      match votes, sum, head with
+      | None, None, None ->
+        PrintBox.asprintf "-"
+      | Some 0, None, None ->
+        PrintBox.empty
+      | Some votes, None, None ->
+        PrintBox.asprintf "%d" votes
+      | Some votes, Some sum, None ->
+        PrintBox.asprintf "%d (%d)" votes sum
+      | Some votes, Some sum, Some head ->
+        PrintBox.asprintf "%d (%d / %d)" votes sum head
+      | _ ->
+        PrintBox.asprintf "??"
+      ) acc
+
+  let acc n =
+    Array.init n (fun _ ->
+        { votes = None; sum = None; head = None; })
+
+  let count_votes_up_to ~matrix ~k ~i =
+    let res = ref 0 in
+    for j = 0 to Matrix.width matrix - 1 do
+      match Matrix.artefact matrix ~i ~j with
+      | Rank r -> if Rank.to_index r <= k then incr res
+      | _ -> failwith "incorrect artefact"
+    done;
+    !res
+
+  let count_sum_up_to ~matrix ~k ~i =
+    let res = ref 0 in
+    for j = 0 to Matrix.width matrix - 1 do
+      match Matrix.artefact matrix ~i ~j with
+      | Rank r -> if Rank.to_index r <= k then res := Rank.rank r + !res
+      | _ -> failwith "incorrect artefact"
+    done;
+    !res
+
+  let cmp_votes ~k = fun cell1 cell2 ->
+    CCOrd.(option int) cell2.(k).votes cell1.(k).votes
+
+  let cmp_sum ~k = fun cell1 cell2 ->
+    CCOrd.(option int) cell1.(k).sum cell2.(k).sum
+
+  let cmp_head ~k = fun cell1 cell2 ->
+    CCOrd.(option int) cell1.(k).head cell2.(k).head
+
+  let set_ranks ~matrix ~start ~stop =
+    if start > stop then ()
+    else begin
+      let tie =
+        Array.init (stop - start + 1)
+          (fun i -> Matrix.target matrix ~i:(start + i))
+      in
+      One.set (Matrix.ranks matrix) start tie
+    end
+
+  let rec rank_votes ~matrix ~k ~start ~stop =
+    let n = Matrix.length matrix in
+    let m = Matrix.width matrix in
+    if start >= stop then set_ranks ~matrix ~start ~stop
+    else if k > n - 1 then
+      rank_head ~matrix ~k ~start ~stop
+    else begin
+      let cursor = ref start in
+      for i = start to stop do
+        let votes = count_votes_up_to ~matrix ~k ~i in
+        (Matrix.get matrix ~i).(k).votes <- Some votes;
+        if votes > m / 2
+        then (Matrix.swap matrix i !cursor; incr cursor)
+      done;
+
+      let have_majority = !cursor - start in
+      if have_majority = 0 then
+        rank_votes ~matrix ~k:(k + 1) ~start ~stop
+      else begin
+        if have_majority = 1 then begin
+          set_ranks ~matrix ~start ~stop:start;
+        end else begin
+          Matrix.sort matrix ~start ~stop:(!cursor - 1) ~cmp:(cmp_votes ~k);
+          Matrix.segments matrix ~start ~stop:(!cursor - 1)
+            ~cmp:(cmp_votes ~k) ~f:(rank_by_sum ~matrix ~k)
+        end;
+        rank_votes ~matrix ~k:(k + 1) ~start:!cursor ~stop
+      end
+    end
+
+  and rank_by_sum ~matrix ~k ~start ~stop =
+    if start >= stop then set_ranks ~matrix ~start ~stop
+    else begin
+      for i = start to stop do
+        let sum = count_sum_up_to ~matrix ~k ~i in
+        (Matrix.get matrix ~i).(k).sum <- Some sum
+      done;
+      Matrix.sort matrix ~start ~stop ~cmp:(cmp_sum ~k);
+      Matrix.segments matrix ~start ~stop
+        ~cmp:(cmp_sum ~k) ~f:(rank_votes ~matrix ~k:(k + 1))
+    end
+
+  and rank_head ~matrix ~k ~start ~stop =
+    match Matrix.head matrix with
+    | None -> set_ranks ~matrix ~start ~stop
+    | Some j ->
+      for i = start to stop do
+        let rank =
+          match Matrix.artefact matrix ~i ~j with
+          | Rank r -> Rank.rank r
+          | _ -> failwith "incorrect artefact"
+        in
+        (Matrix.get matrix ~i).(k).head <- Some rank
+      done;
+      Matrix.sort matrix ~start ~stop ~cmp:(cmp_head ~k);
+      Matrix.segments matrix ~start ~stop ~cmp:(cmp_head ~k)
+        ~f:(set_ranks ~matrix)
+
+  let rank ~conf:() matrix =
+    if Matrix.missing_artefacts matrix <> 0 then
+      Status.Impossible
+    else begin
+      let n = Matrix.length matrix in
+      rank_votes ~matrix ~k:0 ~start:0 ~stop:(n - 1);
+      Status.Complete
+    end
+
+end
+(* Ranking info/explanations *)
+(* ************************************************************************* *)
+
+module Res = struct
+
+  type 'target matrix =
+    | RPSS of (RPSS.acc, 'target) Matrix.t
+    | Yan_weighted of (Yan_weighted.acc, 'target) Matrix.t
+
+  type 'target t = {
+    status : Status.t;
+    info : 'target matrix;
+  }
+
+  let status { status; _ } = status
+
+  let ranking { info; _ } =
+    match info with
+    | RPSS matrix -> Matrix.ranks matrix
+    | Yan_weighted matrix -> Matrix.ranks matrix
+
+  let matrix_box ~pp = function
+    | RPSS matrix ->
+      Matrix.printbox matrix ~pp
+        ~acc_line:RPSS.acc_line ~acc_side:`Right
+    | Yan_weighted matrix ->
+      Matrix.printbox matrix ~pp
+        ~acc_line:Yan_weighted.acc_line ~acc_side:`Left
+
+  let debug ~pp fmt { info; _ } =
+    let box = matrix_box ~pp info in
+    PrintBox_text.pp fmt box
+
+  let map ~targets ~judges { status; info; } =
+    let info =
+      match info with
+      | RPSS matrix -> RPSS (Matrix.map ~targets ~judges matrix)
+      | Yan_weighted matrix -> Yan_weighted (Matrix.map ~targets ~judges matrix)
+    in
+    { status; info; }
+
+end
+
+(* Wrapper for all algorithm types *)
+(* ************************************************************************* *)
+
+module Algorithm = struct
+
+  type t =
+    | RPSS of RPSS.conf
+    | Yan_weighted of Yan_weighted.conf
+  [@@deriving yojson]
+
+  (* Usual functions *)
+  (* *********************************************************************** *)
+
+  let print fmt = function
+    | RPSS () ->
+      Format.fprintf fmt "RPSS"
+    | Yan_weighted conf ->
+      Yan_weighted.print_conf fmt conf
+
+  (* Algorithms Serialization *)
+  (* *********************************************************************** *)
 
   let to_toml = function
-    | RPSS ->
+    | RPSS () ->
       Otoml.array [ Otoml.string "RPSS"; ]
-    | Yan_weighted { weights; head_weights; } ->
-      Otoml.array [ Otoml.string "Yan_weighted";
-                    yan_weights_to_toml weights;
-                    yan_weights_to_toml head_weights ]
+    | Yan_weighted conf ->
+      Otoml.array ( Otoml.string "Yan_weighted" :: Yan_weighted.conf_to_toml conf)
 
   let of_toml t =
     match Otoml.get_array Otoml.get_value t with
-    | [ s ] when Otoml.get_opt Otoml.get_string s = Some "RPSS" ->
-      RPSS
-    | [ s; w; h_w ] when Otoml.get_opt Otoml.get_string s = Some "Yan_weighted" ->
-      let weights = yan_weights_of_toml w in
-      let head_weights = yan_weights_of_toml h_w in
-      Yan_weighted { weights; head_weights; }
+    | s :: _ when Otoml.get_opt Otoml.get_string s = Some "RPSS" ->
+      RPSS ()
+    | s :: r when Otoml.get_opt Otoml.get_string s = Some "Yan_weighted" ->
+      let conf = Yan_weighted.conf_of_toml r in
+      Yan_weighted conf
     | _ ->
       raise (Otoml.Type_error "Not a Ranking algorithm")
 
-
-  (* Algorithms implementations *)
+  (* Ranking computation *)
   (* *********************************************************************** *)
 
-  (*
-  module Yan_weighted = struct
+  let fill_matrix matrix ~get_artefact ~get_bonus =
+    for i = 0 to Matrix.length matrix - 1 do
+      let target = Matrix.target matrix ~i in
+      begin match get_bonus ~target with
+        | None -> ()
+        | Some bonus -> Matrix.acc_bonus matrix ~i ~bonus
+      end;
+      for j = 0 to Matrix.width matrix - 1 do
+        let judge = Matrix.judge matrix ~j in
+        let artefact = get_artefact ~judge ~target in
+        Matrix.acc_artefact matrix ~i ~j ~artefact
+      done
+    done
 
-    let get_artefacts ~st ~phase =
-      State.query_list_where ~st ~conv:
+  let rank ~judges ~head ~targets ~get_artefact ~get_bonus ~t : _ Res.t =
+    let aux ~debug:_ ~conf ~acc ~rank =
+      let matrix = Matrix.init ~head ~judges ~targets ~acc in
+      fill_matrix matrix ~get_artefact ~get_bonus;
+      let status = rank ~conf matrix in
+      status, matrix
+    in
+    match (t : t) with
+    | RPSS conf ->
+      let status, matrix =
+        aux ~conf ~acc:RPSS.acc ~rank:RPSS.rank
+          ~debug:(fun fmt matrix -> Res.debug ~pp:Id.print fmt {status = Partial; info = RPSS matrix; })
+      in
+      { status; info = RPSS matrix; }
+    | Yan_weighted conf ->
+      let status, matrix =
+        aux ~conf ~acc:Yan_weighted.acc ~rank:Yan_weighted.rank
+          ~debug:(fun fmt matrix -> Res.debug ~pp:Id.print fmt {status = Partial; info = Yan_weighted matrix; })
+      in
+      { status; info = Yan_weighted matrix; }
 
+  let compute ~judges ~head ~targets ~get_artefact ~get_bonus ~t =
+    rank ~judges ~head ~targets ~get_artefact ~get_bonus ~t
 
-
-  end
-*)
 end

--- a/src/lib/ranking.mli
+++ b/src/lib/ranking.mli
@@ -4,24 +4,109 @@
 (* Type description *)
 (* ************************************************************************* *)
 
+module Status : sig
 
-(* Algorithms *)
+  type t =
+    | Complete
+    | Partial
+    | Impossible
+
+  val print : Format.formatter -> t -> unit
+
+end
+
+module One : sig
+
+  type 'a ranked =
+    | None
+    | Ranked of {
+        rank : Rank.t;
+        target:  'a;
+      }
+    | Tie of {
+        rank : Rank.t;
+        tie : 'a array;
+      }
+
+  type 'a t = {
+    ranks : 'a ranked array;
+  }
+
+  type with_heat_ids = Id.t t
+
+  val print :
+    pp:(Format.formatter -> 'a -> unit) ->
+    Format.formatter -> 'a t -> unit
+
+  val map_targets : f:('a -> 'b) -> 'a t -> 'b t
+
+  val get : 'a t -> Rank.t -> (Rank.t * 'a) option
+
+end
+
+
+(*  Algorithms - RPSS *)
 (* ************************************************************************* *)
 
-module Algorithm : sig
+module RPSS : sig
 
-  type yan_weight = {
+  type conf = unit
+
+end
+
+(*  Algorithms - Yans weighted *)
+(* ************************************************************************* *)
+
+module Yan_weighted : sig
+
+  type weight = {
     yes : int;
     alt : int;
     no : int;
   } [@@deriving yojson]
 
+  type conf = {
+    weights : weight list;
+    head_weights : weight list;
+  } [@@deriving yojson]
+
+end
+
+(* Algorithm results *)
+(* ************************************************************************* *)
+
+module Res : sig
+
+  type 'target t
+
+  val status : _ t -> Status.t
+  (** Status of a ranking result *)
+
+  val ranking : 'target t -> 'target One.t
+  (* Ranking from a result. *)
+
+  val map :
+    targets:('a -> 'b) ->
+    judges:('a -> 'b) ->
+    'a t -> 'b t
+  (** Map over the targets *)
+
+  val debug :
+    pp:(Format.formatter -> 'target -> unit) ->
+    Format.formatter -> 'target t -> unit
+  (** debug printing *)
+
+end
+
+(* Wrapper type *)
+(* ************************************************************************* *)
+
+module Algorithm : sig
+
   type t =
-    | RPSS
-    | Yan_weighted of {
-        weights : yan_weight list;
-        head_weights : yan_weight list;
-      } [@@deriving yojson]
+    | RPSS of RPSS.conf
+    | Yan_weighted of Yan_weighted.conf
+  [@@deriving yojson]
   (** The type for ranking algorithms. *)
 
   val print : Format.formatter -> t -> unit
@@ -33,5 +118,14 @@ module Algorithm : sig
   val of_toml : Otoml.t -> t
   (** Deserialization from toml.
       @raise Otoml.Type_error *)
+
+  val compute :
+    judges:Judge.id list ->
+    head:Judge.id option ->
+    targets:Id.t list ->
+    get_artefact:(judge:Judge.id -> target:Id.t -> Artefact.t) ->
+    get_bonus:(target:Id.t -> int option) ->
+    t:t -> Id.t Res.t
+  (** Compute the result of a ranking algorithm *)
 
 end

--- a/src/lib/results.ml
+++ b/src/lib/results.ml
@@ -52,8 +52,9 @@ let to_int t =
       | Not_present -> 0
       | Present -> 255
       | Ranked r ->
+        let i = Rank.rank r in
         (* we encode each rank using 1 byte *)
-        assert (r <= 254); r
+        assert (1 <= i && i <= 254); i
     in
     i lsl (n * 8)
   in
@@ -69,7 +70,7 @@ let of_int i =
     match j with
     | 0 -> Not_present
     | 255 -> Present
-    | _ -> Ranked j
+    | _ -> Ranked (Rank.mk j)
   in
   {
     prelims = aux i 2;

--- a/src/lib/round.ml
+++ b/src/lib/round.ml
@@ -47,7 +47,7 @@ let p = Sqlite3_utils.Ty.([int])
 let conv = Conv.mk p of_int
 
 let () =
-  State.add_init_descr_table
+  State.add_init_descr_table ()
     ~table_name:"round_names" ~to_int
     ~to_descr:to_string ~values:[
       Prelims; Finals;

--- a/src/lib/state.ml
+++ b/src/lib/state.ml
@@ -6,18 +6,34 @@ let src = Logs.Src.create "ftw.db"
 (* Type definition *)
 (* ************************************************************************* *)
 
-type t = Sqlite3.db
+type t = {
+  main : Sqlite3.db;
+}
+
+type db =
+  | Main
+  | Users
+
 
 (* DB creation & initialization *)
 (* ************************************************************************* *)
 
 let initializers = ref []
 
+let add_init ~name f =
+  initializers := (name, f) :: !initializers
+
+let sqldb ~db { main; } =
+  match db with
+  | Main -> main
+  | Users -> failwith "TODO"
+
 let mk ~init path =
-  let st = Sqlite3.db_open path in
+  let main = Sqlite3.db_open path in
   (* Enable foreign keys so that the "REFERENCES" uses in tables are
      actually enforced and checked. *)
-  Sqlite3_utils.exec0_exn st {| PRAGMA foreign_keys = ON |};
+  Sqlite3_utils.exec0_exn main {| PRAGMA foreign_keys = ON |};
+  let st = { main; } in
   if init then begin
     Logs.debug ~src (fun k->k "Starting DB initialization");
     List.iter (fun (name, f)->
@@ -40,16 +56,14 @@ let mk ~init path =
   end;
   st
 
-let add_init ~name f =
-  initializers := (name, f) :: !initializers
-
 (* Helper for intializing tables that are mainly here so that the DB can
    be (more or less) self-describing, or at least a bit more readable
    without context. *)
-let add_init_descr_table ~table_name ~to_int ~to_descr ~values =
+let add_init_descr_table ?(db=Main) ~table_name ~to_int ~to_descr ~values () =
   let aux st =
+    let db = sqldb ~db st in
     (* create table *)
-    Sqlite3_utils.exec0_exn st (Format.asprintf {|
+    Sqlite3_utils.exec0_exn db (Format.asprintf {|
       CREATE TABLE IF NOT EXISTS %s (
         id INTEGER PRIMARY KEY,
         name TEXT UNIQUE)
@@ -58,7 +72,7 @@ let add_init_descr_table ~table_name ~to_int ~to_descr ~values =
     List.iter (fun value ->
         let name = to_descr value in
         let open Sqlite3_utils.Ty in
-        Sqlite3_utils.exec_no_cursor_exn st ~ty:[ int; text; ]
+        Sqlite3_utils.exec_no_cursor_exn db ~ty:[ int; text; ]
           (Format.asprintf
              {| INSERT OR IGNORE INTO %s (id, name) VALUES (?,?) |} table_name)
           (to_int value) name
@@ -70,65 +84,49 @@ let add_init_descr_table ~table_name ~to_int ~to_descr ~values =
 (* Helper/Wrapper functions *)
 (* ************************************************************************* *)
 
-let atomically st ~f =
-  Sqlite3_utils.atomically st f
+let atomically { main; } ~f =
+  Sqlite3_utils.atomically main (fun main ->
+      f { main; }
+    )
 
-let exec ~st sql =
+let exec ?(db=Main) ~st sql =
   let open Sqlite3_utils in
-  exec0_exn st sql
+  exec0_exn (sqldb ~db st) sql
 
-let insert ~ty ~st sql =
+let insert ?(db=Main) ~ty ~st sql =
   let open Sqlite3_utils in
-  exec_no_cursor_exn st sql ~ty
+  exec_no_cursor_exn (sqldb ~db st) sql ~ty
 
-let query_all ~f ~conv ~st sql =
+let query_all ?(db=Main) ~f ~conv ~st sql =
   let Conv.Conv (p, res) = conv in
   let open Sqlite3_utils in
-  exec_no_params_exn st sql
+  exec_no_params_exn (sqldb ~db st) sql
     ~ty:(p, res) ~f:(Sqlite3_utils.Cursor.iter ~f)
 
-let query_list ~conv ~st sql =
+let query_list ?(db=Main) ~conv ~st sql =
   let Conv.Conv (p, res) = conv in
   let open Sqlite3_utils in
-  exec_no_params_exn st sql
+  exec_no_params_exn (sqldb ~db st) sql
     ~ty:(p, res) ~f:(Sqlite3_utils.Cursor.to_list)
 
-let query_all_where ~f ~p ~conv ~st sql =
+let query_all_where ?(db=Main) ~f ~p ~conv ~st sql =
   let Conv.Conv (res, f_conv) = conv in
   let open Sqlite3_utils in
-  exec_exn st sql
+  exec_exn (sqldb ~db st) sql
     ~ty:(p, res, f_conv)
     ~f:(Sqlite3_utils.Cursor.iter ~f)
 
-let query_list_where ~p ~conv ~st sql =
+let query_list_where ?(db=Main) ~p ~conv ~st sql =
   let Conv.Conv (res, f_conv) = conv in
   let open Sqlite3_utils in
-  exec_exn st sql
+  exec_exn (sqldb ~db st) sql
     ~ty:(p, res, f_conv)
     ~f:(Sqlite3_utils.Cursor.to_list)
 
-let query_one_where ~p ~conv ~st sql =
+let query_one_where ?(db=Main) ~p ~conv ~st sql =
   let Conv.Conv (res, f_conv) = conv in
   let open Sqlite3_utils in
-  exec_exn st sql
+  exec_exn (sqldb ~db st) sql
     ~ty:(p, res, f_conv)
     ~f:(Sqlite3_utils.Cursor.get_one_exn)
 
-(* TODO: this doesn't do anything really, fix this *)
-module DatabaseVersion = struct
-
-  type t = Id.t
-
-  let to_int = fun a -> a
-
-  let to_string = string_of_int
-
-  let () =
-    add_init_descr_table
-      ~table_name:"database_version" ~to_int
-      ~to_descr:to_string ~values:[
-      2
-    ]
-end
-
-let _ = DatabaseVersion.to_string 1

--- a/src/lib/target.ml
+++ b/src/lib/target.ml
@@ -1,0 +1,105 @@
+
+(* This file is free software, part of FTW. See file "LICENSE" for more information *)
+
+(* Type definitions *)
+(* ************************************************************************* *)
+
+type single = [ `Single ]
+type couple = [ `Couple ]
+type trouple = [ `Trouple ]
+
+type kind = [ single | couple | trouple ]
+
+type ('kind, 'a) t =
+  | Single :
+      { target : 'a; role : Role.t; } -> (single, 'a) t
+  | Couple :
+      { leader : 'a; follower : 'a; } -> (couple, 'a) t
+  | Trouple :
+      { dancer1 : 'a; dancer2 : 'a; dancer3 : 'a; } -> (trouple, 'a) t
+
+type 'a any = Any : (_, 'a) t -> 'a any
+
+
+(* Usual functions *)
+(* ************************************************************************* *)
+
+let map (type kind a b) ~f:(f: (a -> b)) (t : (kind, a) t) : (kind, b) t =
+  match t with
+  | Single { target; role; } ->
+    Single { target = f target; role; }
+  | Couple { leader; follower; } ->
+    Couple { leader = f leader; follower = f follower; }
+  | Trouple { dancer1; dancer2; dancer3; } ->
+    Trouple { dancer1 = f dancer1; dancer2 = f dancer2; dancer3 = f dancer3; }
+
+let map_any ~f (Any target) = Any (map ~f target)
+
+let print_single pp fmt (Single { target; role; }) =
+  Format.fprintf fmt "%a:%a" Role.print_compact role pp target
+
+let print_couple pp fmt (Couple { leader; follower; }) =
+  Format.fprintf fmt "%a & %a" pp leader pp follower
+
+let print_trouple pp fmt (Trouple {dancer1; dancer2; dancer3; }) =
+  Format.fprintf fmt "%a & %a & %a" pp dancer1 pp dancer2 pp dancer3
+
+let print pp fmt = function
+  | Any (Single _ as s) -> print_single pp fmt s
+  | Any (Couple _ as c) -> print_couple pp fmt c
+  | Any (Trouple _ as t) -> print_trouple pp fmt t
+
+
+(* Serialization *)
+(* ************************************************************************* *)
+
+let to_toml (Any t) =
+  match t with
+  | Single { target; role; } ->
+    Otoml.inline_table [
+      "target", Id.to_toml target;
+      "role", Role.to_toml role;
+    ]
+  | Couple { leader; follower; } ->
+    Otoml.inline_table [
+      "leader", Id.to_toml leader;
+      "follower", Id.to_toml follower;
+    ]
+  | Trouple { dancer1; dancer2; dancer3; } ->
+    Otoml.inline_table [
+      "dancer1", Id.to_toml dancer1;
+      "dancer2", Id.to_toml dancer2;
+      "dancer3", Id.to_toml dancer3;
+    ]
+
+let of_toml_single t =
+  let open Misc.Opt in
+  let+ target = Otoml.find_opt t Id.of_toml ["target"] in
+  let+ role = Otoml.find_opt t Role.of_toml ["role"] in
+  Some (Single { target; role})
+
+let of_toml_couple t =
+  let open Misc.Opt in
+  let+ leader = Otoml.find_opt t Id.of_toml ["leader"] in
+  let+ follower = Otoml.find_opt t Id.of_toml ["follower"] in
+  Some (Couple { leader; follower; })
+
+let of_toml_trouple t =
+  let open Misc.Opt in
+  let+ dancer1 = Otoml.find_opt t Id.of_toml ["dancer1"] in
+  let+ dancer2 = Otoml.find_opt t Id.of_toml ["dancer2"] in
+  let+ dancer3 = Otoml.find_opt t Id.of_toml ["dancer3"] in
+  Some (Trouple { dancer1; dancer2; dancer3; })
+
+let of_toml t =
+  match of_toml_single t with
+  | Some single -> Any single
+  | None ->
+    match of_toml_couple t with
+    | Some couple -> Any couple
+    | None ->
+      match of_toml_trouple t with
+      | Some trouple -> Any trouple
+      | None -> raise (Otoml.Type_error "not a bib target")
+
+

--- a/tests/archive/2022-05-27_P4T.toml
+++ b/tests/archive/2022-05-27_P4T.toml
@@ -44,7 +44,7 @@ artefacts="""
 Léa, Cimelli	Adrien, Nykol	Gabija, Purlyte	Guillaume, De Longuemar	Héloise, Vallerio	Lucille, Vignaud	Phillipe, Lam
 #234 Vincent Aron	#133 Alice Martel	1	1	2	1	2	1	4
 #201 Pierre Popineau	#120 Ai-My Le	2	3	1	2	3	3	1
-#204 Huy Hoang Le	#143 Aliénor Langlès	3	4	5	4	1	4	5
+#204 Huy Hoang Le	#143 Aliénor De Saint Léon	3	4	5	4	1	4	5
 #202 Théo Ziakovic	#103 Irène Bivas	5	2	6	3	4	6	2
 #236 Yann Lopez	#129 Valentine Lefrère	4	6	4	5	5	2	3
 #214 Charles Ducros	#132 Albane Desseaux	6	5	3	6	6	5	6
@@ -81,7 +81,7 @@ Phillipe, Lam	Héloise, Vallerio	Gabija, Purlyte	*Léa, Cimelli
 Rank	#	Dancer	Score	TK	M	TW	TK	M	TW	TK	M	TW	TK	M	TW
 1	132	Desseaux Albane	27 / 6	3	3	3	3	3	3	3	3	3	2	2	2
 2	103	Bivas Irène	26 / 9	3	3	3	3	3	3	2	3	3	3	3	3
-3	143	Langlès Aliénor	26 / 8	3	3	3	3	3	2	3	3	3	3	2	3
+3	143	De Saint Léon Aliénor	26 / 8	3	3	3	3	3	2	3	3	3	3	2	3
 4	133	Martel Alice	26 / 5	3	3	3	3	3	2	3	3	3	2	2	1
 5	120	Le Ai-My	24 / 9	2	3	2	3	3	3	3	3	2	3	3	3
 6	129	Lefrère Valentine	23 / 9	3	3	3	3	3	2	2	2	2	3	3	3
@@ -165,7 +165,7 @@ Léa, Cimelli	AiMy, Le	Claire, Parquier	Guillaume, DeGaulle	Mathilde, Varieras	P
 #220 Hugo Manet	#105 Marie-Lou Novene	4	7	7	10	9	6	6
 #215 Amaury Coso	#126 Romy Nguyen	8	6	10	8	7	9	8
 #231 Léo Régnier	#148 Anne-Marie Reclus	5	9	8	5	10	2	9
-#210 Sieffried Loew	#118 Alice Koeler	9	10	5	9	4	10	10
+#210 Siegfried Loew walker	#118 Alice Koeler	9	10	5	9	4	10	10
 """
 
 [event.comps.jj_initie.semifinals]
@@ -181,7 +181,7 @@ Rank	#	Dancer	Score	TK	M	TW	TK	M	TW	TK	M	TW	TK	M	TW
 1	203	Bivas Irène	27 / 9	3	3	3	3	3	3	3	3	3	3	3	3
 2	239	Martel Alice	27 / 9	3	3	3	3	3	3	3	3	3	3	3	3
 3	215	Coso Amaury	26 / 7	2	3	3	3	3	3	3	3	3	3	2	2
-4	210	Loew Sieffried	25 / 5	3	3	3	2	3	3	2	3	3	2	1	2
+4	210	Loew walker Siegfried	25 / 5	3	3	3	2	3	3	2	3	3	2	1	2
 5	230	Abbed Aniss	23 / 9	3	3	3	2	2	2	2	3	3	3	3	3
 6	217	Bellec Nicolas	22 / 9	3	3	2	2	1	2	3	3	3	3	3	3
 7	220	Manet Hugo	22 / 8	3	3	3	1	2	2	2	3	3	2	3	3
@@ -229,7 +229,7 @@ leaders_artefacts="""
 Rank	#	Dancer	Score	TK	M	TW	TK	M	TW	TK	M	TW	TK	M	TW
 1	203	Bivas Irène	27 / 9	3	3	3	3	3	3	3	3	3	3	3	3
 2	239	Martel Alice	27 / 9	3	3	3	3	3	3	3	3	3	3	3	3
-3	210	Loew Sieffried	26 / 8	3	3	3	3	3	2	3	3	3	3	3	2
+3	210	Loew walker Siegfried	26 / 8	3	3	3	3	3	2	3	3	3	3	3	2
 4	215	Coso Amaury	24 / 9	3	3	2	3	3	2	3	3	2	3	3	3
 5	230	Abbed Aniss	24 / 9	2	3	3	2	3	2	3	3	3	3	3	3
 6	231	Régnier Léo	24 / 9	3	3	3	2	2	2	3	3	3	3	3	3
@@ -386,7 +386,7 @@ Simon	Jouveshomme
 Emmanuelle	Kasztelan	# 235	# 146
 Alice	Koeler		# 118
 Philippe	Lam		
-Aliénor	Langlès		# 143
+Aliénor	De Saint Léon		# 143
 Loic	Lavastre		
 Thalie	Law		# 104
 Ai-My	Le		# 120
@@ -400,7 +400,7 @@ Valentine	Lefrère		# 129
 Ninon	Legardinier		
 Jules	Lerouge		
 Maria	Litzler-Italia		
-Sieffried	Loew	# 210	
+Siegfried	Loew walker	# 210	
 Kevin	Loncle	# 226	
 Yann	Lopez	# 236	
 Lilian	Loyer	# 250	
@@ -559,7 +559,7 @@ Simon	Jouveshomme
 Emmanuelle	Kasztelan	# 235	# 146
 Alice	Koeler		# 118
 Philippe	Lam		
-Aliénor	Langlès		# 143
+Aliénor	De Saint Léon		# 143
 Loic	Lavastre		
 Thalie	Law		# 104
 Ai-My	Le		# 120

--- a/tests/schema/run.t
+++ b/tests/schema/run.t
@@ -28,9 +28,6 @@ If the definition changes
 * create migration script src/migration/migrate_V-1_to_V.sql
 * apply to existing database and tests data integrity (with a round trip of exported/imported data)
   $ sqlite3 "test.db" '.schema'
-  CREATE TABLE database_version (
-          id INTEGER PRIMARY KEY,
-          name TEXT UNIQUE);
   CREATE TABLE round_names (
           id INTEGER PRIMARY KEY,
           name TEXT UNIQUE);
@@ -98,6 +95,11 @@ If the definition changes
             PRIMARY KEY(target_id,judge)
             ON CONFLICT REPLACE
           );
+  CREATE TABLE bonus (
+            target_id INTEGER REFERENCES heats(id), -- = target id of judgement
+            bonus INTEGER NOT NULL,
+            PRIMARY KEY(target_id)
+          );
   CREATE TABLE phases (
             id INTEGER PRIMARY KEY,
             competition_id INT REFERENCES competitions(id),
@@ -107,6 +109,13 @@ If the definition changes
             ranking_algorithm TEXT,
             UNIQUE(competition_id, round)
           );
+  CREATE TABLE heats (
+            id INTEGER PRIMARY KEY,
+            phase_id INTEGER REFERENCES phases(id),
+            heat_number INTEGER NOT NULL,
+            leader_id INTEGER REFERENCES dancers(id),
+            follower_id INTEGER REFERENCES dancers(id)
+          );
   CREATE TABLE bibs (
             dancer_id INTEGER REFERENCES dancers(id),
             competition_id INTEGER REFERENCES competitions(id),
@@ -114,18 +123,6 @@ If the definition changes
             role INTEGER NOT NULL,
   
             PRIMARY KEY(bib,competition_id,role)
-          );
-  CREATE TABLE bonus (
-            target_id INTEGER REFERENCES heats(id), -- = target id of judgement
-            bonus INTEGER NOT NULL,
-            PRIMARY KEY(target_id)
-          );
-  CREATE TABLE heats (
-            id INTEGER PRIMARY KEY,
-            phase_id INTEGER REFERENCES phases(id),
-            heat_number INTEGER NOT NULL,
-            leader_id INTEGER REFERENCES dancers(id),
-            follower_id INTEGER REFERENCES dancers(id)
           );
 
 


### PR DESCRIPTION
This PR adds implementation for the current ranking algorithms (RPSS & Yans). This makes it possible to check that the results of a competitions match the rankings of the finals (in the future, we'll also likely check the results for the semi-finals).