### PR TITLE
Fix cumulative import of bibs for comps

### DIFF
--- a/tests/import.t/bib.toml
+++ b/tests/import.t/bib.toml
@@ -1,0 +1,56 @@
+# FTW Event Info
+[config]
+format = "ftw.1"
+
+[event]
+name = "test bib"
+short = "test bib"
+start_date = 2025-12-06
+end_date = 2025-12-06
+
+[event.comps.jj_adv]
+name = "JnJ Advanced"
+kind = "Jack_and_Jill"
+category = "Advanced"
+check_divs = false
+leaders = 2
+follows = 2
+results="""
+"""
+
+[event.comps.jj_inter]
+name = "JnJ Inter"
+kind = "Jack_and_Jill"
+category = "Intermediate"
+check_divs = false
+leaders = 15
+follows = 15
+results="""
+"""
+
+[event.comps.jj_initie]
+name = "JnJ Initié"
+kind = "Jack_and_Jill"
+category = "Novice"
+leaders = 2
+follows = 2
+results="""
+"""
+
+[event.comps.jj_initie.dancers]
+bibs="""
+nom_follow_initie	prenom_follow_initie		# 101
+nom_leader_initie	prenom_leader_initie	# 201	
+"""
+
+[event.comps.jj_inter.dancers]
+bibs="""
+nom_follow_inter	prenom_follow_inter		# 102
+nom_leader_inter	prenom_leader_inter	# 202	
+"""
+
+[event.comps.jj_adv.dancers]
+bibs="""
+nom_follow_adv	prenom_follow_adv		# 103
+nom_leader_adv	prenom_leader_adv	# 203	
+"""

--- a/tests/import.t/run.t
+++ b/tests/import.t/run.t
@@ -1,0 +1,17 @@
+API Full Session Test
+=====================
+
+Initialization
+--------------
+
+Import data
+  $ dune exec -- ftw import --db=test_import.db bib.toml
+
+
+  $ sqlite3 "test_import.db" 'select * from bibs order by competition_id, bib'
+  1|1|103|1
+  2|1|203|0
+  3|2|102|1
+  4|2|202|0
+  5|3|101|1
+  6|3|201|0


### PR DESCRIPTION
The old code accumulated bibs into a map and injected all bindings from the map into the database upon import. The new code avoids that by : 1) adding bibs to the database when theya re parsed (instead of using the dat in the map) and 2) clearing the map when importing new bibs.